### PR TITLE
Add SVG setup modules

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,6 @@
+export const SVG_WIDTH = 1040;
+export const SVG_HEIGHT = 420;
+export const MARGIN = { top: 20, right: 20, bottom: 60, left: 20 }; // Increased bottom for labels
+export const COLUMN_LABELS = ["Hundreds", "Tens", "Ones"];
+export const COLUMN_GAP = 20;
+// ... more later

--- a/js/main.js
+++ b/js/main.js
@@ -1,1 +1,4 @@
-// Main entry point for D3 Regrouping Visualizer
+import { setupSVG } from './svgSetup.js';
+
+const svgContext = setupSVG();
+// console.log("SVG Setup Complete", svgContext);

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,0 +1,49 @@
+import * as d3 from 'd3'; // Assuming D3 is available globally or manage imports
+import { SVG_WIDTH, SVG_HEIGHT, MARGIN, COLUMN_LABELS, COLUMN_GAP } from './constants.js';
+
+export function setupSVG() {
+  const svg = d3.select("#visualization")
+    .append("svg")
+    .attr("width", SVG_WIDTH)
+    .attr("height", SVG_HEIGHT);
+
+  const chartWidth = SVG_WIDTH - MARGIN.left - MARGIN.right;
+  const chartHeight = SVG_HEIGHT - MARGIN.top - MARGIN.bottom;
+
+  const g = svg.append("g")
+    .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+
+  const columnWidth = (chartWidth - (COLUMN_GAP * (COLUMN_LABELS.length - 1))) / COLUMN_LABELS.length;
+
+  // Column Backgrounds and Labels
+  COLUMN_LABELS.forEach((label, i) => {
+    const xPos = i * (columnWidth + COLUMN_GAP);
+    g.append("rect")
+      .attr("class", `column-bg column-${label.toLowerCase()}`)
+      .attr("x", xPos)
+      .attr("y", 0)
+      .attr("width", columnWidth)
+      .attr("height", chartHeight)
+      .attr("fill", "#f0f0f0")
+      .attr("stroke", "#ddd");
+
+    g.append("text")
+      .attr("class", `column-label column-label-${label.toLowerCase()}`)
+      .attr("x", xPos + columnWidth / 2)
+      .attr("y", chartHeight + MARGIN.bottom / 2 - 10)
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "middle")
+      .text(label);
+  });
+
+  // Placeholder for column text info
+  COLUMN_LABELS.forEach((label, i) => {
+     const xPos = i * (columnWidth + COLUMN_GAP);
+     g.append("g")
+        .attr("class", `column-text-group column-text-${label.toLowerCase()}`)
+        .attr("transform", `translate(${xPos}, 0)`);
+  });
+
+
+  return { svg, g, chartWidth, chartHeight, columnWidth };
+}

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,4 +1,5 @@
-import * as d3 from 'd3'; // Assuming D3 is available globally or manage imports
+// D3 is loaded globally via a script tag in index.html
+// so we can reference the global `d3` object directly here.
 import { SVG_WIDTH, SVG_HEIGHT, MARGIN, COLUMN_LABELS, COLUMN_GAP } from './constants.js';
 
 export function setupSVG() {


### PR DESCRIPTION
## Summary
- add constants for SVG drawing settings
- build svgSetup helper to render columns and labels
- initialize SVG canvas in main.js

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844022347e4832db95586518643204a